### PR TITLE
Release 2.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tox" %}
-{% set version = "2.8.1" %}
-{% set sha256 = "de0abf4e8992c056bc22afff9d969e0cae2e39452a9650bdbcbe7154793537b7" %}
+{% set version = "2.3.0" %}
+{% set sha256 = "b73fa8a74a9fa7ad5c942bee8a28eadd9d25882fd21b04f86bec051cc2cdadf5" %}
 
 package:
   name: {{ name|lower }}
@@ -12,9 +12,10 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: python setup.py install --single-version-externally-managed --record record.txt
+
 
 requirements:
   build:
@@ -24,7 +25,7 @@ requirements:
   run:
     - python
     - py >=1.4.17 
-    - pluggy >=0.3.0,<1.0
+    - pluggy >=0.3.0,<0.4.0
     - virtualenv >=1.11.2
     - setuptools
    


### PR DESCRIPTION
Closes https://github.com/conda-forge/tox-feedstock/pull/1

Releases a legacy version of `tox`. Just a rebased and squash version of PR ( https://github.com/conda-forge/tox-feedstock/pull/1 ), which resolves some conflicts.