### PR TITLE
tox 3.14.6, update six/virtualenv deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.14.3" %}
+{% set version = "3.14.6" %}
 
 package:
   name: tox
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tox/tox-{{ version }}.tar.gz
-  sha256: 06ba73b149bf838d5cd25dc30c2dd2671ae5b2757cf98e5c41a35fe449f131b3
+  sha256: a4a6689045d93c208d77230853b28058b7513f5123647b67bf012f82fa168303
 
 build:
-  number: 2
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - tox = tox:cmdline
@@ -26,8 +26,8 @@ requirements:
     - packaging >=14
     - py >=1.4.17, <2
     - pluggy >=0.12.0,<1
-    - virtualenv >=16.0.0
-    - six >=1.0.0,<2
+    - virtualenv >=16.0.0, !=20.0.0, !=20.0.1, !=20.0.2, !=20.0.3, !=20.0.4, !=20.0.5, !=20.0.6, !=20.0.7
+    - six >=1.14.0,<2
     - toml >=0.9.4
     - filelock >=3.0.0,<4
     - colorama >=0.4.1  # [win]


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- alternative to #54 (was pretty out-of-date vs the recent stuff)
- updates dep pins
  - virtualenv (even though the clobbered versions aren't/shouldn't be available, see https://github.com/conda-forge/virtualenv-feedstock/pull/31)
  - six